### PR TITLE
Remove erroneous keys in the parsed object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,19 +14,21 @@
       var result = {};
       var entries = linksHeader.split(',');
       // compile regular expressions ahead of time for efficiency
-      var relsRegExp = /\brel="?([^"]+)"?\s*;?/;
-      var keysRegExp = /(\b[0-9a-z\.-]+\b)/g;
+      var relsRegExp = /\brel=(?:"([^"]+)"|([^";,]+)(?:[;,]|$))/;
+      var keysRegExp = /([^\s]+)/g;
       var sourceRegExp = /^<(.*)>/;
 
       for (var i = 0; i < entries.length; i++) {
         var entry = entries[i].trim();
+        var source = sourceRegExp.exec(entry);
         var rels = relsRegExp.exec(entry);
-        if (rels) {
-          var keys = rels[1].match(keysRegExp);
-          var source = sourceRegExp.exec(entry)[1];
+        if (source && rels) {
+          var href = source[1];
+          var rel = rels[1] || rels[2];
+          var keys = rel.match(keysRegExp);
           var k, kLength = keys.length;
           for (k = 0; k < kLength; k += 1) {
-            result[keys[k]] = source
+            result[keys[k]] = href;
           }
         }
       }

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,18 +1,24 @@
-require('chai').should();
+var should = require('chai').should();
 var li     = require('../lib');
 
 var fixture = '</api/users?page=0&per_page=2>; rel="first", ' +
               '</api/users?page=1&per_page=2>; rel="next", ' +
               '</api/users?page=3&per_page=2>; rel="last", ' +
               '</api/users/123>; rel="self", ' +
-              '</api/users/12345>; rel="related alternate"';
+              '</api/users/12345>; rel="related alternate", ' +
+              '</api/users?name=Joe+Bloggs>; rel="http://example.org/search-results", ' +
+              '</api/users?status=registered>; rel="http://example.org/status-result collection"';
+var quotfixture = '</api/users/1>; rel=home,'+
+                  '</api/users/2>; rel=only one';
 
 var linksObject = {
-  first               : '/api/users?page=0&per_page=2',
-  next                : '/api/users?page=1&per_page=2',
-  last                : '/api/users?page=3&per_page=2',
-  self                : '/api/users/123',
-  'related alternate' : '/api/users/12345'
+  first                                        : '/api/users?page=0&per_page=2',
+  next                                         : '/api/users?page=1&per_page=2',
+  last                                         : '/api/users?page=3&per_page=2',
+  self                                         : '/api/users/123',
+  'related alternate'                          : '/api/users/12345',
+  'http://example.org/search-results'          : '/api/users?name=Joe+Bloggs',
+  'http://example.org/status-result collection': '/api/users?status=registered'
 };
 
 describe('parse-links', function () {
@@ -25,6 +31,19 @@ describe('parse-links', function () {
       parsed.self.should.eql('/api/users/123');
       parsed.alternate.should.eql('/api/users/12345');
       parsed.related.should.eql('/api/users/12345');
+      parsed['http://example.org/search-results'].should.eql('/api/users?name=Joe+Bloggs');
+      parsed['http://example.org/status-result'].should.eql('/api/users?status=registered');
+      parsed.collection.should.eql('/api/users?status=registered');
+      Object.keys(parsed).length.should.eql(9);
+    });
+  });
+
+  describe('parse links without quotes!', function() {
+    it('should parse a links string without rels into an object', function () {
+      var parsed = li.parse(quotfixture);
+      parsed.home.should.eql('/api/users/1');
+      parsed.only.should.eql('/api/users/2');
+      parsed.one.should.eql('/api/users/2');
     });
   });
 


### PR DESCRIPTION
If you parse a link header containing extension relations, it creates a bunch of erroneous keys. This is fixed by matching all non-whitespace characters within `rels`.

So:

```
$ node
> var Li = require('li')
> Li.parse('</api/users/1>; rel="http://example.org/rels/user"')
{ http: '/api/users/1',
  'example.org': '/api/users/1',
  rels: '/api/users/1',
  user: '/api/users/1' }
```

Becomes:

```
$ node
> var Li = require('./)
> Li.parse('</api/users/1>; rel="http://example.org/rels/user"')
{ 'http://example.org/rels/user': '/api/users/1' }
```
