### PR TITLE
Fixed: allow commas in links

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@
   return {
     parse: function (linksHeader) {
       var result = {};
-      var entries = linksHeader.split(',');
+      var entries = linksHeader.split(/,(?![^<]*>)/g);
       // compile regular expressions ahead of time for efficiency
       var relsRegExp = /\brel=(?:"([^"]+)"|([^";,]+)(?:[;,]|$))/;
       var keysRegExp = /([^\s]+)/g;

--- a/test/tests.js
+++ b/test/tests.js
@@ -7,7 +7,8 @@ var fixture = '</api/users?page=0&per_page=2>; rel="first", ' +
               '</api/users/123>; rel="self", ' +
               '</api/users/12345>; rel="related alternate", ' +
               '</api/users?name=Joe+Bloggs>; rel="http://example.org/search-results", ' +
-              '</api/users?status=registered>; rel="http://example.org/status-result collection"';
+              '</api/users?status=registered>; rel="http://example.org/status-result collection", ' +
+              '</api/users?q=smith&fields=fname,lname>; rel="search"';
 var quotfixture = '</api/users/1>; rel=home,'+
                   '</api/users/2>; rel=only one';
 
@@ -18,7 +19,8 @@ var linksObject = {
   self                                         : '/api/users/123',
   'related alternate'                          : '/api/users/12345',
   'http://example.org/search-results'          : '/api/users?name=Joe+Bloggs',
-  'http://example.org/status-result collection': '/api/users?status=registered'
+  'http://example.org/status-result collection': '/api/users?status=registered',
+  'search'                                     : '/api/users?q=smith&fields=fname,lname'
 };
 
 describe('parse-links', function () {
@@ -34,7 +36,8 @@ describe('parse-links', function () {
       parsed['http://example.org/search-results'].should.eql('/api/users?name=Joe+Bloggs');
       parsed['http://example.org/status-result'].should.eql('/api/users?status=registered');
       parsed.collection.should.eql('/api/users?status=registered');
-      Object.keys(parsed).length.should.eql(9);
+      parsed.search.should.eql('/api/users?q=smith&fields=fname,lname');
+      Object.keys(parsed).length.should.eql(10);
     });
   });
 


### PR DESCRIPTION
Fixed issue raised in parse-links repository where links with commas cause unexpected results (https://github.com/jfromaniello/parse-links/issues/4).
